### PR TITLE
Create exercise subsections

### DIFF
--- a/notebooks/python/python-exercises.ipynb
+++ b/notebooks/python/python-exercises.ipynb
@@ -28,13 +28,16 @@
     "\n",
     "```python\n",
     "a = [1, 2, 3, 4, 5]\n",
-    "```\n",
-    "\n",
-    "\n",
-    "\n",
-    "```\n",
-    "Inline Exercise 1.1: Replace the '1' in the list with the string 'foo'.\n",
     "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise 1.1\n",
+    "\n",
+    "Replace the '1' in the list with the string 'foo'."
    ]
   },
   {
@@ -69,9 +72,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "```\n",
-    "Inline Exercise 1.2: Replace the `4` in the list `a` with the string `bar`.\n",
-    "```"
+    "### Exercise 1.2\n",
+    "\n",
+    "Replace the `4` in the list `a` with the string `bar`."
    ]
   },
   {
@@ -108,10 +111,16 @@
    "source": [
     "In Python, all sequences, be they lists, strings, or tuples, support indexing, which allows for the direct access of individual items within the sequence. \n",
     "The numbering of these indices starts from zero (`0`); hence, the initial item in any sequence is found at the zeroth index. \n",
-    "This implies that for a sequence of `n` elements, the last item would be positioned at an index of `n-1`.\n",
-    "```\n",
-    "Inline Exercise 1.3: Given the list `a`, guess what the output of `print(a[-1])` will print.\n",
-    "```"
+    "This implies that for a sequence of `n` elements, the last item would be positioned at an index of `n-1`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise 1.3\n",
+    "\n",
+    "Given the list `a`, guess what the output of `print(a[-1])` will print."
    ]
   },
   {
@@ -149,11 +158,16 @@
     "Another unique feature of sequence indexing in Python is the support for negative indices, which provide a means to count from the end of the sequence towards the beginning. \n",
     "Utilizing this approach, the last item of any given sequence can be accessed using an index of `-1`. \n",
     "Progressively, moving further towards the start of the sequence, the indices decrease, meaning the penultimate item would be at index `-2`, and so forth. \n",
-    "Remarkably, the first item in a sequence can also be accessed using negative indexing by specifying the negative of the sequence's length, denoted as `-length`.\n",
+    "Remarkably, the first item in a sequence can also be accessed using negative indexing by specifying the negative of the sequence's length, denoted as `-length`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise 1.4\n",
     "\n",
-    "```\n",
-    "Inline Exercise 1.4: Given the list `a`, modify `a` so that the output is `[1, 2, \"hello\", \"world\", 4, 5]`.\n",
-    "```"
+    "Given the list `a`, modify `a` so that the output is `[1, 2, \"hello\", \"world\", 4, 5]`."
    ]
   },
   {
@@ -190,11 +204,16 @@
    "source": [
     "In Python, slicing allows you to access a subset or a range of elements from a sequence-like object such as a list, string, or tuple. \n",
     "This can be accomplished by specifying two indices in the format `s[i:j]`, where `s` is the sequence. \n",
-    "This expression denotes a slice starting at index `i` and ending just before index `j`.\n",
+    "This expression denotes a slice starting at index `i` and ending just before index `j`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise 1.5\n",
     "\n",
-    "```\n",
-    "Inline Exercise 1.5: After setting list `b`, what do you expect `print(a[2])` to output? \n",
-    "```"
+    "After setting list `b`, what do you expect `print(a[2])` to output?"
    ]
   },
   {
@@ -239,12 +258,22 @@
     "Therefore, changes made using one variable (like `b[2] = \"small\"`) also appear when accessed through the other (`a`), demonstrating Python's handling of object references.\n",
     "\n",
     "List comprehensions provide a concise way to create lists. \n",
-    "Common applications are to make new lists where each element is the result of some operations applied to each member of another sequence or iterable, or to create a subsequence of those elements that satisfy a certain condition.\n",
+    "Common applications are to make new lists where each element is the result of some operations applied to each member of another sequence or iterable, or to create a subsequence of those elements that satisfy a certain condition."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise 1.6\n",
     "\n",
-    "```\n",
-    "Inline Exercise 1.6: `c` is given as a list comprehension. Find what you think `print(c[3])` will output.\n",
-    "```\n",
-    "\n",
+    "`c` is given as a list comprehension. Find what you think `print(c[3])` will output."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "```python\n",
     "c = [x for x in range(2, 10)] # this is a list comprehension!\n",
     "```"
@@ -285,11 +314,16 @@
    "metadata": {},
    "source": [
     "A list comprehension consists of brackets containing an expression followed by a `for` clause, then zero or more `for` or `if` clauses. \n",
-    "The result will be a new list resulting from evaluating the expression in the context of the `for` and `if` clauses which follow it. \n",
+    "The result will be a new list resulting from evaluating the expression in the context of the `for` and `if` clauses which follow it."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise 1.7\n",
     "\n",
-    "```\n",
-    "Inline Exercise 1.7: Using the list comprehensions in Python, write code that transforms the given list `d = [6, 5, 4, 3, 2]` into `[7, 6, 5, 4, 3]`` by adding 1 to each element. \n",
-    "```"
+    "Using the list comprehensions in Python, write code that transforms the given list `d = [6, 5, 4, 3, 2]` into `[7, 6, 5, 4, 3]` by adding 1 to each element."
    ]
   },
   {
@@ -350,11 +384,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In Python, dictionaries are mutable, which means we can change their content without changing their identity.\n",
+    "In Python, dictionaries are mutable, which means we can change their content without changing their identity."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise 2.1\n",
     "\n",
-    "```\n",
-    "Inline Exercise 2.1: Given the dictionary `d`, change the value of the key `tree` into `leaves`.\n",
-    "```"
+    "Given the dictionary `d`, change the value of the key `tree` into `leaves`."
    ]
   },
   {
@@ -379,11 +418,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In Python, dictionaries are not fixed in size. This means that new key-value pairs can be added to the dictionary at any time.\n",
+    "In Python, dictionaries are not fixed in size. This means that new key-value pairs can be added to the dictionary at any time."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise 2.2\n",
     "\n",
-    "```\n",
-    "Inline Exercise 2.2: Given the dictionary `d`, add a new key-value pair `monty: python` to the dictionary.\n",
-    "```"
+    "Given the dictionary `d`, add a new key-value pair `monty: python` to the dictionary."
    ]
   },
   {
@@ -408,11 +452,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`d[key]` returns the value for key in the dictionary. If key is not available, then a KeyError will be raised.\n",
+    "`d[key]` returns the value for key in the dictionary. If key is not available, then a KeyError will be raised."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise 2.3\n",
     "\n",
-    "```\n",
-    "Inline Exercise 2.3: Given the dictionary `d`, what do you think `print(d[\"earth\"])` will output?\n",
-    "```"
+    "Given the dictionary `d`, what do you think `print(d[\"earth\"])` will output?"
    ]
   },
   {
@@ -448,9 +497,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "```\n",
-    "Inline Exercise 2.4: Print all the pairs in the dictionary `d`.\n",
-    "```"
+    "### Exercise 2.4\n",
+    "\n",
+    "Print all the pairs in the dictionary `d`."
    ]
   },
   {
@@ -756,9 +805,7 @@
    "source": [
     "### Exercise 4.1\n",
     "\n",
-    "```\n",
-    "Inline Exercise 4.1: Write a for loop that prints the entries of the following list, one at a time:\n",
-    "```"
+    "Write a for loop that prints the entries of the following list, one at a time:"
    ]
   },
   {
@@ -802,9 +849,7 @@
    "source": [
     "### Exercise 4.2\n",
     "\n",
-    "```\n",
-    "Inline Exercise 4.2: Write a for loop that computes 2^n only using multiplication by 2.\n",
-    "```"
+    "Write a for loop that computes 2^n only using multiplication by 2."
    ]
   },
   {
@@ -847,9 +892,7 @@
    "source": [
     "### Exercise 4.3\n",
     "\n",
-    "```\n",
-    "Inline Exercise 4.3: Write a for loop that adds 1 to elements in a list and prints their squared value.\n",
-    "```"
+    "Write a for loop that adds 1 to elements in a list and prints their squared value."
    ]
   },
   {

--- a/tests/test_book_content.py
+++ b/tests/test_book_content.py
@@ -20,6 +20,19 @@ def notebook_source(path):
     return "\n".join(chunks)
 
 
+def notebook_markdown_headings(path):
+    notebook = json.loads((ROOT / path).read_text())
+    headings = []
+    for cell in notebook["cells"]:
+        if cell.get("cell_type") != "markdown":
+            continue
+        source = cell.get("source", "")
+        for line in ("".join(source) if isinstance(source, list) else source).splitlines():
+            if line.startswith("#"):
+                headings.append(line.strip())
+    return headings
+
+
 class BookContentTests(unittest.TestCase):
     def test_python_chapter_is_python_basics(self):
         toc = (ROOT / "_toc.yml").read_text()
@@ -82,6 +95,23 @@ class BookContentTests(unittest.TestCase):
                 return
 
         self.fail("Expected the Python Basics notebook to use pd.read_csv")
+
+    def test_python_exercises_have_subsection_headings(self):
+        python_source = notebook_source("notebooks/python/python-exercises.ipynb")
+        headings = notebook_markdown_headings("notebooks/python/python-exercises.ipynb")
+
+        expected_exercise_headings = (
+            *(f"### Exercise 1.{number}" for number in range(1, 8)),
+            *(f"### Exercise 2.{number}" for number in range(1, 5)),
+            *(f"### Exercise 3.{number}" for number in range(1, 7)),
+            *(f"### Exercise 4.{number}" for number in range(1, 4)),
+            *(f"### Exercise 5.{number}" for number in range(1, 3)),
+        )
+        for heading in expected_exercise_headings:
+            with self.subTest(heading=heading):
+                self.assertIn(heading, headings)
+
+        self.assertNotIn("Inline Exercise", python_source)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Promote Python inline exercise prompts into `### Exercise` markdown subsections so they appear in the notebook table of contents.
- Normalize existing for-loop exercise prompts by removing fenced `Inline Exercise` markers while keeping the exercise text.
- Add a content test that verifies every Python Basics exercise heading is present and no `Inline Exercise` markers remain.

## Tests run
- `python -m unittest tests.test_book_content` -> passed (`Ran 8 tests`, `OK`).
- `python -m unittest discover -s tests` -> passed (`Ran 8 tests`, `OK`).
- `git diff --check` -> passed.

## Notes about tests not run
- `jupyter-book build .` was attempted locally, but the installed `jupyter-book` is v2.1.0 and treated the legacy CI command as a file export, printing `No file exports found` instead of building the book. CI installs `jupyter-book<2` from `requirements.txt`, which is the documented environment for this command.

Closes #11
