### PR TITLE
Finish tutorial cleanup for issue 3

### DIFF
--- a/notebooks/exercises/Python/dict_soln.py
+++ b/notebooks/exercises/Python/dict_soln.py
@@ -1,17 +1,12 @@
 d = {"tree": "wood", "flower": "petal", "earth": "water", 101: [4, 6, 8]}
 
-# TODO: INSERT CODE HERE TO REPLACE "wood" WITH "leaves"
 d["tree"] = "leaves"
 
-# TODO: INSERT CODE HERE TO ADD THE PAIR "monty": "python"
 d["monty"] = "python"
 
-# TODO: INSERT CODE HERE TO FIRST CHECK IF "earth" IS A KEY,
-# AND IF IT IS THEN PRINT THE VALUE IT MAPS TO
 if "earth" in d:
     print(d["earth"])
 
-# TODO: INSERT CODE HERE TO PRINT A LIST/GENERATOR OF ALL THE PAIRS IN d
 print(d.items())
 
 print(d) # check all your work

--- a/tests/test_book_content.py
+++ b/tests/test_book_content.py
@@ -40,8 +40,12 @@ class BookContentTests(unittest.TestCase):
         notebook = notebook_source("notebooks/python/python-exercises.ipynb")
 
         self.assertIn("title: Python Basics", toc)
+        self.assertEqual(1, toc.count("title: Python Basics"))
+        self.assertEqual(1, toc.count("notebooks/python/python-exercises.ipynb"))
         self.assertIn("# Python Basics", notebook)
         self.assertNotIn("# Python Fundamentals", notebook)
+        self.assertNotIn("Pyomo Summer Workshop 2018 Exercise Problem - Python", toc)
+        self.assertNotIn("Pyomo Summer Workshop 2018 Exercise Problem - Python", notebook)
 
     def test_placeholder_index_is_not_in_book(self):
         toc = (ROOT / "myst.yml").read_text()
@@ -53,6 +57,22 @@ class BookContentTests(unittest.TestCase):
         for notebook_path in PUBLISHED_NOTEBOOKS:
             with self.subTest(notebook=notebook_path):
                 self.assertNotIn("TODO", notebook_source(notebook_path))
+
+    def test_exercise_todos_are_limited_to_learner_templates(self):
+        exercise_files = tuple((ROOT / "notebooks/exercises").glob("**/*.py"))
+        self.assertGreater(len(exercise_files), 0)
+
+        for path in exercise_files:
+            source = path.read_text()
+            if "TODO" not in source:
+                continue
+
+            relative_path = path.relative_to(ROOT).as_posix()
+            with self.subTest(path=relative_path):
+                self.assertTrue(
+                    path.name.endswith("_incomplete.py"),
+                    f"{relative_path} contains TODO markers but is not a learner template",
+                )
 
     def test_contact_and_branding_are_current(self):
         config = (ROOT / "_config.yml").read_text()


### PR DESCRIPTION
## Summary

- Remove stale TODO prompt comments from the Python dictionary solution file.
- Add content regression coverage that keeps TODO markers limited to intentional learner template files.
- Strengthen the Python chapter check so the old duplicated 2018 exercise section title cannot reappear.

## Tests run

- `uv run --group docs python -m unittest tests.test_book_content` -> passed, 13 tests.
- `uv run --group docs python -m unittest discover -s tests` -> passed, 13 tests.
- `uv run --group docs jupyter book build --html --ci` -> passed, built 4 pages.
- `if grep -R --line-number --fixed-strings "/pyomo-summer-ws//" _build/html; then echo "Generated site contains doubled project base URLs" >&2; exit 1; fi` -> passed, no doubled base URLs found.
- `git diff --check` -> passed.

## Notes

- I did not run separate lint, formatting, or type-check commands because the repository documentation, `pyproject.toml`, and CI workflow do not define any beyond the commands above.

Closes #3
