### PR TITLE
[codex] Reimplement Pyomo tutorials in book

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains the source notebooks for the [Pyomo Tutorial](https://github.com/SECQUOIA/pyomo-summer-ws). The deployed site is available at <https://secquoia.github.io/pyomo-summer-ws/>.
 
-The [SECQUOIA Research Group](https://engineering.purdue.edu/SECQUOIA) maintains the tutorial. The notebooks adapt material from the Pyomo Summer Workshop 2018 and update it for current Python and Pyomo workflows.
+The [SECQUOIA Research Group](https://engineering.purdue.edu/SECQUOIA) maintains the tutorial. The notebooks adapt material from the Pyomo Summer Workshop 2018 and the current [Pyomo tutorials repository](https://github.com/Pyomo/pyomo-tutorials), updating it for current Python and Pyomo workflows.
 
 ## Local build
 
@@ -22,7 +22,9 @@ To preview the built site locally:
 uv run --group docs python -m http.server --directory _build/html 8000
 ```
 
-The notebooks rely on Pyomo. Some examples require GLPK or IPOPT when run interactively; the documentation build renders notebooks without executing them. See `setup.md` for Colab links and solver setup notes.
+The notebooks rely on Pyomo. Some examples require GLPK or IPOPT when run interactively; the Dynamic Systems simulation exercise also uses SciPy when available. The documentation build renders notebooks without executing them. See `setup.md` for Colab links and solver setup notes.
+
+Adapted third-party tutorial material is covered in `THIRD_PARTY_NOTICES.md`.
 
 CI installs Node for the MyST/Jupyter Book HTML build. Local contributors usually only need `uv` unless they are debugging the underlying JavaScript theme tooling. `requirements.txt` is kept as a compatibility pointer to `pyproject.toml` and `uv.lock`.
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,37 @@
+# Third-Party Notices
+
+Portions of the notebooks and exercise files adapt material from the public
+[Pyomo tutorials repository](https://github.com/Pyomo/pyomo-tutorials).
+That material is distributed under the following BSD-style notice.
+
+## Pyomo tutorials
+
+Copyright (c) 2023-2025 National Technology and Engineering Solutions of
+Sandia, LLC. Under the terms of Contract DE-NA0003525 with National
+Technology and Engineering Solutions of Sandia, LLC, the U.S. Government
+retains certain rights in this software.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+- Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+- Neither the name of the Sandia National Laboratories nor the names of its
+  contributors may be used to endorse or promote products derived from this
+  software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/intro.md
+++ b/intro.md
@@ -2,13 +2,13 @@
 
 Welcome to the *Pyomo Tutorial*. The [SECQUOIA Research Group](https://engineering.purdue.edu/SECQUOIA) maintains these notebooks for learners who want a practical introduction to Python-based mathematical optimization with Pyomo.
 
-The tutorial adapts material from the [Pyomo Summer Workshop 2018](http://www.pyomo.org/workshop-examples) and updates it for current Python and Pyomo workflows. It is designed for workshops, classroom use, and self-study.
+The tutorial adapts material from the [Pyomo Summer Workshop 2018](http://www.pyomo.org/workshop-examples) and the current [Pyomo tutorials repository](https://github.com/Pyomo/pyomo-tutorials), updating it for current Python and Pyomo workflows. It is designed for workshops, classroom use, and self-study.
 
 ## Recommended path
 
 [Pyomo](https://en.wikipedia.org/wiki/Pyomo) is a complete and versatile mathematical optimization package for the Python ecosystem. Pyomo provides a means to build models for optimization using the concepts of decision variables, constraints, and objectives from mathematical optimization, then transform and generate solutions using open source or commercial solvers.
 
-Start with [Python Basics](/notebooks/01-python-basics/python-exercises.ipynb), then continue into the Pyomo modeling chapters. Python Basics covers the language patterns used later in the optimization examples, Pyomo Fundamentals introduces modeling components and mixed-integer examples, and Pyomo Nonlinear Problems covers nonlinear models and solver behavior.
+Start with [Python Basics](/notebooks/01-python-basics/python-exercises.ipynb), then continue into the Pyomo modeling chapters. Python Basics covers the language patterns used later in the optimization examples, Pyomo Fundamentals introduces modeling components and mixed-integer examples, and Pyomo Nonlinear Problems covers nonlinear models and solver behavior. The later chapters add structured modeling with blocks, model transformations, dynamic systems, generalized disjunctive programming, and Pyomo debugging utilities.
 
 ## Learning objectives
 
@@ -17,6 +17,8 @@ After completing the tutorial, you should be able to:
 - use core Python data structures and control flow in modeling scripts;
 - formulate Pyomo variables, objectives, constraints, sets, and parameters;
 - solve linear, mixed-integer, and nonlinear Pyomo models with appropriate solvers;
+- organize larger models with blocks and Pyomo transformations;
+- formulate dynamic-system and generalized disjunctive programming examples;
 - diagnose common modeling and solver failures;
 - adapt the examples for new classroom or self-study exercises.
 
@@ -36,4 +38,4 @@ The [SECQUOIA Research Group](https://engineering.purdue.edu/SECQUOIA) develops 
 
 Individual contributors include David Bernal, Zedong Peng, Hamta Bardool, and Albert Lee.
 
-These materials adapt the public Pyomo workshop examples and Pyomo modeling references. Notebook-specific references appear in the relevant chapters.
+These materials adapt the public Pyomo workshop examples and Pyomo modeling references. Notebook-specific references appear in the relevant chapters, and third-party notice details are collected in [Third-Party Notices](./THIRD_PARTY_NOTICES.md).

--- a/myst.yml
+++ b/myst.yml
@@ -14,6 +14,16 @@ project:
       title: Python Basics
     - file: notebooks/02-pyomo-fundamentals/Fundamentals.ipynb
     - file: notebooks/03-pyomo-nonlinear/PyomoNonlinear.ipynb
+    - file: notebooks/04-structured-modeling/BlocksAndTransformations.ipynb
+      title: Blocks and Model Transformations
+    - file: notebooks/05-dynamic-systems/DynamicSystems.ipynb
+      title: Dynamic Systems
+    - file: notebooks/06-gdp/GDP.ipynb
+      title: Generalized Disjunctive Programming
+    - file: notebooks/07-contrib-debugging/ContribAndDebugging.ipynb
+      title: Pyomo contrib and Debugging Tools
+    - file: THIRD_PARTY_NOTICES.md
+      title: Third-Party Notices
 site:
   template: book-theme
   options:

--- a/notebooks/04-structured-modeling/BlocksAndTransformations.ipynb
+++ b/notebooks/04-structured-modeling/BlocksAndTransformations.ipynb
@@ -1,0 +1,369 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a8b8d627",
+   "metadata": {},
+   "source": [
+    "# Blocks and Model Transformations\n",
+    "\n",
+    "[Open this notebook in Colab](https://colab.research.google.com/github/SECQUOIA/pyomo-summer-ws/blob/main/notebooks/04-structured-modeling/BlocksAndTransformations.ipynb).\n",
+    "\n",
+    "This notebook is part of the [SECQUOIA Research Group](https://engineering.purdue.edu/SECQUOIA) Pyomo Tutorial. It adapts the structured-modeling and transformation themes from the public Pyomo workshop tutorials into short exercises. Install GLPK before running the mixed-integer examples locally; see [Setup and Solvers](../../setup.md) for solver notes.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "680d0a48",
+   "metadata": {},
+   "source": [
+    "## Learning objectives\n",
+    "\n",
+    "By the end of this chapter, you should be able to:\n",
+    "\n",
+    "- use `Block` objects to organize variables, expressions, and constraints by subsystem;\n",
+    "- write block rules that create repeatable model structure;\n",
+    "- inspect a structured model without flattening away the hierarchy;\n",
+    "- explain the difference between a model and a solver-ready formulation;\n",
+    "- apply a Pyomo transformation and compare the transformed formulation to the original model.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "da66bae9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-11T19:28:12.244578Z",
+     "iopub.status.busy": "2026-05-11T19:28:12.244443Z",
+     "iopub.status.idle": "2026-05-11T19:28:12.411782Z",
+     "shell.execute_reply": "2026-05-11T19:28:12.410817Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import pyomo.environ as pyo\n",
+    "\n",
+    "\n",
+    "def solve_with_glpk(model):\n",
+    "    solver = pyo.SolverFactory(\"glpk\")\n",
+    "    if not solver.available(False):\n",
+    "        print(\"GLPK is not available; the model was built but not solved.\")\n",
+    "        return None\n",
+    "    results = solver.solve(model)\n",
+    "    print(f\"termination: {results.solver.termination_condition}\")\n",
+    "    return results\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "97ee7e29",
+   "metadata": {},
+   "source": [
+    "## 1. Structured modeling with Blocks\n",
+    "\n",
+    "Large algebraic models usually have repeated structure: a plant has units, a network has arcs, a scenario model has one block per scenario, and a decomposition algorithm often needs one block per subproblem. A `Block` lets you keep that structure in the Pyomo object model instead of encoding every component at the top level.\n",
+    "\n",
+    "### Exercise 1.1. Build a product block\n",
+    "\n",
+    "The example below creates one block per product. Each block owns its local production variable, setup decision, parameters, expression, and capacity-linking constraint. The top-level model only contains the shared labor limit and objective.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "c23f6d0f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-11T19:28:12.413656Z",
+     "iopub.status.busy": "2026-05-11T19:28:12.413387Z",
+     "iopub.status.idle": "2026-05-11T19:28:12.544213Z",
+     "shell.execute_reply": "2026-05-11T19:28:12.543352Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "termination: optimal\n",
+      "standard: make= 40.0, open=  1, revenue= 320.0\n",
+      "premium : make=  4.0, open=  1, revenue=  56.0\n",
+      "profit: 326.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "def build_product_model():\n",
+    "    products = [\"standard\", \"premium\"]\n",
+    "    margin = {\"standard\": 8, \"premium\": 14}\n",
+    "    labor = {\"standard\": 2, \"premium\": 5}\n",
+    "    capacity = {\"standard\": 40, \"premium\": 25}\n",
+    "    setup = {\"standard\": 20, \"premium\": 30}\n",
+    "\n",
+    "    model = pyo.ConcreteModel()\n",
+    "    model.PRODUCTS = pyo.Set(initialize=products)\n",
+    "\n",
+    "    def product_block(block, product):\n",
+    "        block.make = pyo.Var(bounds=(0, capacity[product]))\n",
+    "        block.open = pyo.Var(within=pyo.Binary)\n",
+    "        block.margin = pyo.Param(initialize=margin[product])\n",
+    "        block.labor = pyo.Param(initialize=labor[product])\n",
+    "        block.capacity = pyo.Param(initialize=capacity[product])\n",
+    "        block.setup = pyo.Param(initialize=setup[product])\n",
+    "        block.revenue = pyo.Expression(expr=block.margin * block.make)\n",
+    "        block.setup_cost = pyo.Expression(expr=block.setup * block.open)\n",
+    "        block.capacity_link = pyo.Constraint(expr=block.make <= block.capacity * block.open)\n",
+    "\n",
+    "    model.product = pyo.Block(model.PRODUCTS, rule=product_block)\n",
+    "    model.labor_limit = pyo.Constraint(\n",
+    "        expr=sum(model.product[p].labor * model.product[p].make for p in model.PRODUCTS) <= 100\n",
+    "    )\n",
+    "    model.profit = pyo.Objective(\n",
+    "        expr=sum(model.product[p].revenue - model.product[p].setup_cost for p in model.PRODUCTS),\n",
+    "        sense=pyo.maximize,\n",
+    "    )\n",
+    "    return model\n",
+    "\n",
+    "\n",
+    "structured_model = build_product_model()\n",
+    "solve_with_glpk(structured_model)\n",
+    "\n",
+    "for product in structured_model.PRODUCTS:\n",
+    "    block = structured_model.product[product]\n",
+    "    print(\n",
+    "        f\"{product:8s}: make={pyo.value(block.make):5.1f}, \"\n",
+    "        f\"open={pyo.value(block.open):3.0f}, revenue={pyo.value(block.revenue):6.1f}\"\n",
+    "    )\n",
+    "print(f\"profit: {pyo.value(structured_model.profit):.1f}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d23c9a0f",
+   "metadata": {},
+   "source": [
+    "### Exercise 1.2. Inspect the model hierarchy\n",
+    "\n",
+    "A block-structured model is still a normal Pyomo model. You can traverse it as a tree when that is useful, or ask Pyomo for all active variables and constraints when a solver or analysis routine needs the flattened view.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "f30a60a1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-11T19:28:12.546202Z",
+     "iopub.status.busy": "2026-05-11T19:28:12.546036Z",
+     "iopub.status.idle": "2026-05-11T19:28:12.550208Z",
+     "shell.execute_reply": "2026-05-11T19:28:12.549369Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Local variables by product block:\n",
+      "  product[standard]: vars=['make', 'open'], constraints=['capacity_link']\n",
+      "  product[premium]: vars=['make', 'open'], constraints=['capacity_link']\n",
+      "flattened variable count: 4\n",
+      "flattened constraint count: 3\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Local variables by product block:\")\n",
+    "for product in structured_model.PRODUCTS:\n",
+    "    block = structured_model.product[product]\n",
+    "    local_vars = [var.local_name for var in block.component_objects(pyo.Var)]\n",
+    "    local_cons = [con.local_name for con in block.component_objects(pyo.Constraint)]\n",
+    "    print(f\"  {block.name}: vars={local_vars}, constraints={local_cons}\")\n",
+    "\n",
+    "flat_vars = list(structured_model.component_data_objects(pyo.Var, active=True))\n",
+    "flat_cons = list(structured_model.component_data_objects(pyo.Constraint, active=True))\n",
+    "print(f\"flattened variable count: {len(flat_vars)}\")\n",
+    "print(f\"flattened constraint count: {len(flat_cons)}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f33a1a1f",
+   "metadata": {},
+   "source": [
+    "### Exercise 1.3. Add a shared constraint outside the blocks\n",
+    "\n",
+    "Blocks do not prevent coupling. The labor constraint above couples the product blocks through the top-level model. Add a second shared constraint that limits total setup decisions to one product, then resolve. How does the production plan change?\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "e540b297",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-11T19:28:12.551908Z",
+     "iopub.status.busy": "2026-05-11T19:28:12.551759Z",
+     "iopub.status.idle": "2026-05-11T19:28:12.560753Z",
+     "shell.execute_reply": "2026-05-11T19:28:12.560051Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "termination: optimal\n",
+      "standard: make= 40.0, open=  1\n",
+      "premium : make=  0.0, open=  0\n",
+      "profit: 300.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "one_setup_model = build_product_model()\n",
+    "one_setup_model.one_setup = pyo.Constraint(\n",
+    "    expr=sum(one_setup_model.product[p].open for p in one_setup_model.PRODUCTS) <= 1\n",
+    ")\n",
+    "solve_with_glpk(one_setup_model)\n",
+    "\n",
+    "for product in one_setup_model.PRODUCTS:\n",
+    "    block = one_setup_model.product[product]\n",
+    "    print(f\"{product:8s}: make={pyo.value(block.make):5.1f}, open={pyo.value(block.open):3.0f}\")\n",
+    "print(f\"profit: {pyo.value(one_setup_model.profit):.1f}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3626b626",
+   "metadata": {},
+   "source": [
+    "## 2. Model transformations\n",
+    "\n",
+    "A model is the representation you want to write and maintain. A formulation is the algebraic form handed to a solver. Pyomo transformations rewrite one model representation into another while keeping the original modeling intent explicit.\n",
+    "\n",
+    "### Exercise 2.1. Relax integrality\n",
+    "\n",
+    "The next cell relaxes the binary setup variables to continuous variables between 0 and 1. This is not the same problem as the mixed-integer model, but it is a useful diagnostic formulation: the relaxed objective is an upper bound for the maximization model.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "f1c3a636",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-11T19:28:12.561935Z",
+     "iopub.status.busy": "2026-05-11T19:28:12.561819Z",
+     "iopub.status.idle": "2026-05-11T19:28:12.570477Z",
+     "shell.execute_reply": "2026-05-11T19:28:12.569831Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "termination: optimal\n",
+      "standard: make= 40.0, open= 1.00, open_bounds=(0, 1)\n",
+      "premium : make=  4.0, open= 0.16, open_bounds=(0, 1)\n",
+      "relaxed profit: 351.2\n"
+     ]
+    }
+   ],
+   "source": [
+    "relaxed_model = build_product_model()\n",
+    "pyo.TransformationFactory(\"core.relax_integer_vars\").apply_to(relaxed_model)\n",
+    "solve_with_glpk(relaxed_model)\n",
+    "\n",
+    "for product in relaxed_model.PRODUCTS:\n",
+    "    block = relaxed_model.product[product]\n",
+    "    print(\n",
+    "        f\"{product:8s}: make={pyo.value(block.make):5.1f}, \"\n",
+    "        f\"open={pyo.value(block.open):5.2f}, open_bounds={block.open.bounds}\"\n",
+    "    )\n",
+    "print(f\"relaxed profit: {pyo.value(relaxed_model.profit):.1f}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "81f069fe",
+   "metadata": {},
+   "source": [
+    "### Exercise 2.2. Compare model and formulation counts\n",
+    "\n",
+    "The transformed model keeps the same block hierarchy, but the setup variables no longer have a binary domain. Use the counts and the solution values to explain why the relaxed formulation is easier for a linear solver and why its solution may not be implementable.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "ef62955f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-11T19:28:12.572031Z",
+     "iopub.status.busy": "2026-05-11T19:28:12.571885Z",
+     "iopub.status.idle": "2026-05-11T19:28:12.575240Z",
+     "shell.execute_reply": "2026-05-11T19:28:12.574558Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "mixed-integer: vars= 4, constraints= 3, binary_vars=2\n",
+      "relaxed      : vars= 4, constraints= 3, binary_vars=0\n"
+     ]
+    }
+   ],
+   "source": [
+    "for name, model in [(\"mixed-integer\", structured_model), (\"relaxed\", relaxed_model)]:\n",
+    "    binary_vars = [var for var in model.component_data_objects(pyo.Var) if var.is_binary()]\n",
+    "    print(\n",
+    "        f\"{name:13s}: vars={len(list(model.component_data_objects(pyo.Var))):2d}, \"\n",
+    "        f\"constraints={len(list(model.component_data_objects(pyo.Constraint, active=True))):2d}, \"\n",
+    "        f\"binary_vars={len(binary_vars)}\"\n",
+    "    )\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f9833ca6",
+   "metadata": {},
+   "source": [
+    "## Exercises to continue\n",
+    "\n",
+    "1. Rebuild the lot-sizing model from [Pyomo Fundamentals](../02-pyomo-fundamentals/Fundamentals.ipynb) with one block per time period.\n",
+    "2. Add a block-level expression for each period's holding and backlog cost.\n",
+    "3. Relax the period setup variables, solve the relaxed formulation, and compare the result to the original mixed-integer model.\n",
+    "\n",
+    "## References\n",
+    "\n",
+    "The Pyomo `Block` and transformation patterns used here are standard Pyomo modeling tools [@bynum2021pyomo].\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/05-dynamic-systems/DynamicSystems.ipynb
+++ b/notebooks/05-dynamic-systems/DynamicSystems.ipynb
@@ -1,0 +1,401 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "d138e8c7",
+   "metadata": {},
+   "source": [
+    "# Dynamic Systems\n",
+    "\n",
+    "[Open this notebook in Colab](https://colab.research.google.com/github/SECQUOIA/pyomo-summer-ws/blob/main/notebooks/05-dynamic-systems/DynamicSystems.ipynb).\n",
+    "\n",
+    "This notebook is part of the [SECQUOIA Research Group](https://engineering.purdue.edu/SECQUOIA) Pyomo Tutorial. It adapts the dynamic-system exercises from the public Pyomo workshop tutorials. The discretized optimization examples use IPOPT; see [Setup and Solvers](../../setup.md) for solver notes.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0bc907d7",
+   "metadata": {},
+   "source": [
+    "## Learning objectives\n",
+    "\n",
+    "By the end of this chapter, you should be able to:\n",
+    "\n",
+    "- represent differential variables with `ContinuousSet` and `DerivativeVar`;\n",
+    "- connect differential equations, initial conditions, and algebraic constraints in Pyomo;\n",
+    "- discretize dynamic models with finite differences and collocation;\n",
+    "- use simulation as a check before optimization when SciPy is available;\n",
+    "- formulate a small dynamic parameter-estimation problem.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "cddc12c5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-11T19:28:32.143750Z",
+     "iopub.status.busy": "2026-05-11T19:28:32.143615Z",
+     "iopub.status.idle": "2026-05-11T19:28:32.320041Z",
+     "shell.execute_reply": "2026-05-11T19:28:32.319145Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import shutil\n",
+    "import subprocess\n",
+    "import sys\n",
+    "\n",
+    "import pyomo.environ as pyo\n",
+    "from pyomo.dae import ContinuousSet, DerivativeVar, Simulator\n",
+    "\n",
+    "if \"google.colab\" in sys.modules and shutil.which(\"ipopt\") is None:\n",
+    "    subprocess.run([sys.executable, \"-m\", \"pip\", \"install\", \"-q\", \"idaes-pse\"], check=True)\n",
+    "    subprocess.run([\"idaes\", \"get-extensions\"], check=True)\n",
+    "    os.environ[\"PATH\"] = \"/root/.idaes/bin:\" + os.environ[\"PATH\"]\n",
+    "\n",
+    "\n",
+    "def solve_with_ipopt(model):\n",
+    "    solver = pyo.SolverFactory(\"ipopt\")\n",
+    "    if not solver.available(False):\n",
+    "        print(\"IPOPT is not available; the model was built but not solved.\")\n",
+    "        return None\n",
+    "    results = solver.solve(model)\n",
+    "    print(f\"termination: {results.solver.termination_condition}\")\n",
+    "    return results\n",
+    "\n",
+    "\n",
+    "def analytical_z(t):\n",
+    "    return (4 * t - 3) / (4 * t + 1)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "94e2de75",
+   "metadata": {},
+   "source": [
+    "## 1. Differential equations by hand\n",
+    "\n",
+    "The first exercise uses the scalar initial-value problem `dz/dt = z**2 - 2*z + 1`, with `z(0) = -3`. The analytical solution is `z(t) = (4*t - 3)/(4*t + 1)`. We will first discretize the derivative manually with a backward finite difference.\n",
+    "\n",
+    "### Exercise 1.1. Manual finite difference\n",
+    "\n",
+    "Starting from [`small_findiff_soln.py`](../exercises/Dynamic/exercises-1/small_findiff_soln.py), identify the algebraic variables created at each time point and compare the numerical values against the analytical solution.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "785c1ae2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-11T19:28:32.322220Z",
+     "iopub.status.busy": "2026-05-11T19:28:32.321872Z",
+     "iopub.status.idle": "2026-05-11T19:28:32.506387Z",
+     "shell.execute_reply": "2026-05-11T19:28:32.505513Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "termination: optimal\n",
+      " i    t       z_model   z_exact\n",
+      " 0   0.00   -3.0000   -3.0000\n",
+      " 1   0.25   -1.4721   -1.0000\n",
+      " 2   0.50   -0.7267   -0.3333\n",
+      " 3   0.75   -0.3026    0.0000\n",
+      " 4   1.00   -0.0348    0.2000\n"
+     ]
+    }
+   ],
+   "source": [
+    "numpoints = 5\n",
+    "findiff = pyo.ConcreteModel()\n",
+    "findiff.points = pyo.RangeSet(0, numpoints - 1)\n",
+    "findiff.h = pyo.Param(initialize=1.0 / (numpoints - 1))\n",
+    "findiff.z = pyo.Var(findiff.points)\n",
+    "findiff.dzdt = pyo.Var(findiff.points)\n",
+    "findiff.obj = pyo.Objective(expr=1)\n",
+    "\n",
+    "@findiff.Constraint(findiff.points)\n",
+    "def zdot(model, i):\n",
+    "    return model.dzdt[i] == model.z[i] ** 2 - 2 * model.z[i] + 1\n",
+    "\n",
+    "@findiff.Constraint(findiff.points)\n",
+    "def backward_difference(model, i):\n",
+    "    if i == 0:\n",
+    "        return pyo.Constraint.Skip\n",
+    "    return model.dzdt[i] == (model.z[i] - model.z[i - 1]) / model.h\n",
+    "\n",
+    "findiff.initial_condition = pyo.Constraint(expr=findiff.z[0] == -3)\n",
+    "\n",
+    "result = solve_with_ipopt(findiff)\n",
+    "if result is not None:\n",
+    "    print(\" i    t       z_model   z_exact\")\n",
+    "    for i in findiff.points:\n",
+    "        t = pyo.value(findiff.h) * i\n",
+    "        print(f\"{i:2d}  {t:5.2f}  {pyo.value(findiff.z[i]):8.4f}  {analytical_z(t):8.4f}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2bf4a975",
+   "metadata": {},
+   "source": [
+    "## 2. Pyomo DAE discretization\n",
+    "\n",
+    "Manual discretizations are useful for learning, but `pyomo.dae` can generate the finite-difference or collocation equations for you. The continuous model stays close to the differential equation, and the transformation creates the algebraic formulation.\n",
+    "\n",
+    "### Exercise 2.1. Collocation with `pyomo.dae`\n",
+    "\n",
+    "Starting from [`small_dae_soln.py`](../exercises/Dynamic/exercises-1/small_dae_soln.py), change `nfe` and `ncp` and observe how the number of discretization points changes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "76f906fc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-11T19:28:32.508023Z",
+     "iopub.status.busy": "2026-05-11T19:28:32.507847Z",
+     "iopub.status.idle": "2026-05-11T19:28:32.627099Z",
+     "shell.execute_reply": "2026-05-11T19:28:32.626329Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "termination: optimal\n",
+      "discretization points: 13\n",
+      "t=0.0000, z= -3.0000, exact= -3.0000\n",
+      "t=0.0388, z= -2.4773, exact= -2.4630\n",
+      "t=0.1612, z= -1.4212, exact= -1.4317\n",
+      "t=0.2500, z= -1.0000, exact= -1.0000\n",
+      "t=0.2888, z= -0.8571, exact= -0.8561\n",
+      "t=0.4112, z= -0.5115, exact= -0.5123\n",
+      "...\n",
+      "t=1.0000, z=  0.2000, exact=  0.2000\n"
+     ]
+    }
+   ],
+   "source": [
+    "dae_model = pyo.ConcreteModel()\n",
+    "dae_model.t = ContinuousSet(bounds=(0, 1))\n",
+    "dae_model.z = pyo.Var(dae_model.t)\n",
+    "dae_model.dzdt = DerivativeVar(dae_model.z)\n",
+    "dae_model.obj = pyo.Objective(expr=1)\n",
+    "\n",
+    "@dae_model.Constraint(dae_model.t)\n",
+    "def dae_zdot(model, t):\n",
+    "    return model.dzdt[t] == model.z[t] ** 2 - 2 * model.z[t] + 1\n",
+    "\n",
+    "dae_model.initial_condition = pyo.Constraint(expr=dae_model.z[0] == -3)\n",
+    "\n",
+    "pyo.TransformationFactory(\"dae.collocation\").apply_to(\n",
+    "    dae_model, nfe=4, ncp=3, scheme=\"LAGRANGE-RADAU\"\n",
+    ")\n",
+    "\n",
+    "result = solve_with_ipopt(dae_model)\n",
+    "if result is not None:\n",
+    "    time_points = list(dae_model.t)\n",
+    "    print(f\"discretization points: {len(time_points)}\")\n",
+    "    for t in time_points[:6]:\n",
+    "        print(f\"t={float(t):6.4f}, z={pyo.value(dae_model.z[t]):8.4f}, exact={analytical_z(float(t)):8.4f}\")\n",
+    "    print(\"...\")\n",
+    "    t = time_points[-1]\n",
+    "    print(f\"t={float(t):6.4f}, z={pyo.value(dae_model.z[t]):8.4f}, exact={analytical_z(float(t)):8.4f}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "977fe424",
+   "metadata": {},
+   "source": [
+    "## 3. Simulation before optimization\n",
+    "\n",
+    "When a model has fixed inputs and no optimization decisions, simulation is often the fastest way to check signs, units, and initial conditions. The workshop simulation exercise models a consecutive reaction from A to B.\n",
+    "\n",
+    "### Exercise 3.1. Simulate a reaction model\n",
+    "\n",
+    "The `Simulator` interface uses SciPy for this exercise. If SciPy is missing in a local environment, the model-building pattern is still the same and the simulation cell reports the missing dependency.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "7a502927",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-11T19:28:32.628842Z",
+     "iopub.status.busy": "2026-05-11T19:28:32.628556Z",
+     "iopub.status.idle": "2026-05-11T19:28:33.151219Z",
+     "shell.execute_reply": "2026-05-11T19:28:33.150455Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "final simulated concentrations\n",
+      "  a[{t}]: 0.0067\n",
+      "  b[{t}]: 0.4514\n"
+     ]
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    import scipy  # noqa: F401\n",
+    "except Exception as err:\n",
+    "    print(f\"SciPy is not available, so the simulation step is skipped: {err}\")\n",
+    "else:\n",
+    "    sim_model = pyo.ConcreteModel()\n",
+    "    sim_model.t = ContinuousSet(bounds=(0, 1))\n",
+    "    sim_model.a = pyo.Var(sim_model.t)\n",
+    "    sim_model.b = pyo.Var(sim_model.t)\n",
+    "    sim_model.k1 = pyo.Param(initialize=5)\n",
+    "    sim_model.k2 = pyo.Param(initialize=1)\n",
+    "    sim_model.dadt = DerivativeVar(sim_model.a)\n",
+    "    sim_model.dbdt = DerivativeVar(sim_model.b)\n",
+    "    sim_model.a[0].fix(1)\n",
+    "    sim_model.b[0].fix(0)\n",
+    "\n",
+    "    @sim_model.Constraint(sim_model.t)\n",
+    "    def a_balance(model, t):\n",
+    "        return model.dadt[t] == -model.k1 * model.a[t]\n",
+    "\n",
+    "    @sim_model.Constraint(sim_model.t)\n",
+    "    def b_balance(model, t):\n",
+    "        return model.dbdt[t] == model.k1 * model.a[t] - model.k2 * model.b[t]\n",
+    "\n",
+    "    simulator = Simulator(sim_model, package=\"scipy\")\n",
+    "    tsim, profiles = simulator.simulate(integrator=\"vode\", numpoints=25)\n",
+    "    print(\"final simulated concentrations\")\n",
+    "    for index, var in enumerate(simulator.get_variable_order()):\n",
+    "        print(f\"  {var}: {profiles[-1, index]:.4f}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "77b15bbe",
+   "metadata": {},
+   "source": [
+    "## 4. Dynamic parameter estimation\n",
+    "\n",
+    "Parameter estimation embeds the dynamic model in an optimization problem. The objective penalizes mismatch between model predictions and measurements, while the differential equations constrain the trajectory.\n",
+    "\n",
+    "### Exercise 4.1. Estimate reaction-rate constants\n",
+    "\n",
+    "Starting from [`start_param_est2.py`](../exercises/Dynamic/exercises-1/start_param_est2.py), complete the variables, differential equations, objective, discretization, and solve. A full solution is available in [`param_est2_soln.py`](../exercises/Dynamic/exercises-1/param_est2_soln.py).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "95165470",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-11T19:28:33.153468Z",
+     "iopub.status.busy": "2026-05-11T19:28:33.153142Z",
+     "iopub.status.idle": "2026-05-11T19:28:33.261867Z",
+     "shell.execute_reply": "2026-05-11T19:28:33.260962Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "termination: optimal\n",
+      "k1 = 5.0035\n",
+      "k2 = 1.0000\n",
+      "sum of squared errors = 0.000001\n"
+     ]
+    }
+   ],
+   "source": [
+    "a_conc = {0.1: 0.606, 0.2: 0.368, 0.3: 0.223, 0.4: 0.135, 0.5: 0.082,\n",
+    "          0.6: 0.050, 0.7: 0.030, 0.8: 0.018, 0.9: 0.011, 1.0: 0.007}\n",
+    "b_conc = {0.1: 0.373, 0.2: 0.564, 0.3: 0.647, 0.4: 0.669, 0.5: 0.656,\n",
+    "          0.6: 0.624, 0.7: 0.583, 0.8: 0.539, 0.9: 0.494, 1.0: 0.451}\n",
+    "\n",
+    "est = pyo.ConcreteModel()\n",
+    "est.meas_time = pyo.Set(initialize=sorted(a_conc), ordered=True)\n",
+    "est.ameas = pyo.Param(est.meas_time, initialize=a_conc)\n",
+    "est.bmeas = pyo.Param(est.meas_time, initialize=b_conc)\n",
+    "est.time = ContinuousSet(initialize=est.meas_time, bounds=(0, 1))\n",
+    "est.a = pyo.Var(est.time, bounds=(0, 1))\n",
+    "est.b = pyo.Var(est.time, bounds=(0, 1))\n",
+    "est.dadt = DerivativeVar(est.a)\n",
+    "est.dbdt = DerivativeVar(est.b)\n",
+    "est.k1 = pyo.Var(bounds=(0, 10), initialize=4)\n",
+    "est.k2 = pyo.Var(bounds=(0, 10), initialize=1)\n",
+    "\n",
+    "@est.Constraint(est.time)\n",
+    "def a_diffeq(model, t):\n",
+    "    return model.dadt[t] == -model.k1 * model.a[t]\n",
+    "\n",
+    "@est.Constraint(est.time)\n",
+    "def b_diffeq(model, t):\n",
+    "    return model.dbdt[t] == model.k1 * model.a[t] - model.k2 * model.b[t]\n",
+    "\n",
+    "est.ainit = pyo.Constraint(expr=est.a[0] == 1)\n",
+    "est.binit = pyo.Constraint(expr=est.b[0] == 0)\n",
+    "est.obj = pyo.Objective(\n",
+    "    expr=sum((est.a[t] - est.ameas[t]) ** 2 + (est.b[t] - est.bmeas[t]) ** 2 for t in est.meas_time)\n",
+    ")\n",
+    "\n",
+    "pyo.TransformationFactory(\"dae.collocation\").apply_to(est, nfe=10, ncp=3, scheme=\"LAGRANGE-RADAU\")\n",
+    "\n",
+    "result = solve_with_ipopt(est)\n",
+    "if result is not None:\n",
+    "    print(f\"k1 = {pyo.value(est.k1):.4f}\")\n",
+    "    print(f\"k2 = {pyo.value(est.k2):.4f}\")\n",
+    "    print(f\"sum of squared errors = {pyo.value(est.obj):.6f}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "40978986",
+   "metadata": {},
+   "source": [
+    "## Exercises to continue\n",
+    "\n",
+    "1. Replace the collocation discretization in Exercise 4.1 with finite differences and compare the estimated parameters.\n",
+    "2. Add bounds to `k1` and `k2` that reflect prior physical knowledge, then solve again.\n",
+    "3. Use the solution trajectory to report residuals at each measured time point.\n",
+    "\n",
+    "## References\n",
+    "\n",
+    "Dynamic optimization and DAE discretization patterns are part of Pyomo's modeling extensions [@bynum2021pyomo].\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/06-gdp/GDP.ipynb
+++ b/notebooks/06-gdp/GDP.ipynb
@@ -1,0 +1,338 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "64b120e9",
+   "metadata": {},
+   "source": [
+    "# Generalized Disjunctive Programming\n",
+    "\n",
+    "[Open this notebook in Colab](https://colab.research.google.com/github/SECQUOIA/pyomo-summer-ws/blob/main/notebooks/06-gdp/GDP.ipynb).\n",
+    "\n",
+    "This notebook is part of the [SECQUOIA Research Group](https://engineering.purdue.edu/SECQUOIA) Pyomo Tutorial. It adapts the GDP strip-packing exercise from the public Pyomo workshop tutorials. The transformed examples use GLPK; see [Setup and Solvers](../../setup.md) for solver notes.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4e0acbfc",
+   "metadata": {},
+   "source": [
+    "## Learning objectives\n",
+    "\n",
+    "By the end of this chapter, you should be able to:\n",
+    "\n",
+    "- express logical alternatives with `Disjunction` objects;\n",
+    "- explain why GDP keeps modeling intent clearer than hand-written big-M constraints;\n",
+    "- transform a GDP model to a mixed-integer formulation with big-M or hull reformulations;\n",
+    "- solve a transformed GDP model with a MIP solver;\n",
+    "- inspect which disjuncts are active in the solved model.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "768327cf",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-11T19:28:34.062422Z",
+     "iopub.status.busy": "2026-05-11T19:28:34.062287Z",
+     "iopub.status.idle": "2026-05-11T19:28:34.230567Z",
+     "shell.execute_reply": "2026-05-11T19:28:34.229550Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import pyomo.environ as pyo\n",
+    "from pyomo.gdp import Disjunction\n",
+    "\n",
+    "\n",
+    "def solve_with_glpk(model):\n",
+    "    solver = pyo.SolverFactory(\"glpk\")\n",
+    "    if not solver.available(False):\n",
+    "        print(\"GLPK is not available; the model was built but not solved.\")\n",
+    "        return None\n",
+    "    results = solver.solve(model)\n",
+    "    print(f\"termination: {results.solver.termination_condition}\")\n",
+    "    return results\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8e3c5695",
+   "metadata": {},
+   "source": [
+    "## 1. Logical alternatives in algebraic models\n",
+    "\n",
+    "GDP is useful when a model has explicit alternatives: one unit is active or bypassed, one rectangle is left of another or below it, or one operating mode is selected. Pyomo lets you state those alternatives directly as disjunctions, then transform the model for a solver.\n",
+    "\n",
+    "The workshop exercise packs rectangles into a strip of fixed width while minimizing strip length. For each pair of rectangles, at least one no-overlap relation must hold.\n",
+    "\n",
+    "### Exercise 1.1. Build the strip-packing GDP model\n",
+    "\n",
+    "Start from [`stripPacking.py`](../exercises/GDP/exercises-1/stripPacking.py) and insert the no-overlap disjunctions. A complete solution is available in [`stripPacking_soln.py`](../exercises/GDP/exercises-1/stripPacking_soln.py).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "6bc51df4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-11T19:28:34.232903Z",
+     "iopub.status.busy": "2026-05-11T19:28:34.232579Z",
+     "iopub.status.idle": "2026-05-11T19:28:34.243343Z",
+     "shell.execute_reply": "2026-05-11T19:28:34.242604Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "rectangle pairs requiring a disjunction: 6\n",
+      "disjuncts for pair (0, 1): 4\n"
+     ]
+    }
+   ],
+   "source": [
+    "def build_strip_packing_model():\n",
+    "    model = pyo.ConcreteModel()\n",
+    "    model.RECTANGLES = pyo.Set(ordered=True, initialize=[0, 1, 2, 3])\n",
+    "    model.Width = pyo.Param(model.RECTANGLES, initialize={0: 6, 1: 3, 2: 4, 3: 2})\n",
+    "    model.Length = pyo.Param(model.RECTANGLES, initialize={0: 6, 1: 8, 2: 5, 3: 3})\n",
+    "    model.StripWidth = pyo.Param(initialize=10)\n",
+    "    model.LengthUB = pyo.Param(initialize=sum(model.Length[i] for i in model.RECTANGLES))\n",
+    "    model.x = pyo.Var(model.RECTANGLES, bounds=(0, model.LengthUB))\n",
+    "\n",
+    "    def y_bounds(model, i):\n",
+    "        return (0, model.StripWidth - model.Width[i])\n",
+    "\n",
+    "    model.y = pyo.Var(model.RECTANGLES, bounds=y_bounds)\n",
+    "    model.MaxLength = pyo.Var(within=pyo.NonNegativeReals, bounds=(0, model.LengthUB))\n",
+    "\n",
+    "    def rec_pairs_filter(model, i, j):\n",
+    "        return i < j\n",
+    "\n",
+    "    model.OVERLAP_PAIRS = pyo.Set(\n",
+    "        initialize=model.RECTANGLES * model.RECTANGLES,\n",
+    "        dimen=2,\n",
+    "        filter=rec_pairs_filter,\n",
+    "    )\n",
+    "\n",
+    "    @model.Constraint(model.RECTANGLES)\n",
+    "    def strip_ends_after_last_rec(model, i):\n",
+    "        return model.MaxLength >= model.x[i] + model.Length[i]\n",
+    "\n",
+    "    model.total_length = pyo.Objective(expr=model.MaxLength)\n",
+    "\n",
+    "    @model.Disjunction(model.OVERLAP_PAIRS)\n",
+    "    def no_overlap(model, i, j):\n",
+    "        return [\n",
+    "            model.x[i] + model.Length[i] <= model.x[j],\n",
+    "            model.x[j] + model.Length[j] <= model.x[i],\n",
+    "            model.y[i] + model.Width[i] <= model.y[j],\n",
+    "            model.y[j] + model.Width[j] <= model.y[i],\n",
+    "        ]\n",
+    "\n",
+    "    return model\n",
+    "\n",
+    "\n",
+    "gdp_model = build_strip_packing_model()\n",
+    "print(f\"rectangle pairs requiring a disjunction: {len(gdp_model.OVERLAP_PAIRS)}\")\n",
+    "print(f\"disjuncts for pair (0, 1): {len(gdp_model.no_overlap[0, 1].disjuncts)}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ca22650c",
+   "metadata": {},
+   "source": [
+    "## 2. Transforming a GDP model\n",
+    "\n",
+    "A GDP model is not sent directly to GLPK. Pyomo rewrites the disjunctions into a mixed-integer formulation. The big-M reformulation is often compact; the hull reformulation is often tighter but can create more variables and constraints.\n",
+    "\n",
+    "### Exercise 2.1. Apply the big-M transformation\n",
+    "\n",
+    "Because all rectangle coordinates have finite bounds, Pyomo can estimate valid M values for this small model.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "8adc0ace",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-11T19:28:34.245450Z",
+     "iopub.status.busy": "2026-05-11T19:28:34.245290Z",
+     "iopub.status.idle": "2026-05-11T19:28:34.380746Z",
+     "shell.execute_reply": "2026-05-11T19:28:34.380061Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "termination: optimal\n",
+      "minimum strip length: 11.0\n",
+      "rectangle 0: x= 0.0, y= 4.0, length=6, width=6\n",
+      "rectangle 1: x= 0.0, y= 0.0, length=8, width=3\n",
+      "rectangle 2: x= 6.0, y= 3.0, length=5, width=4\n",
+      "rectangle 3: x= 8.0, y= 0.0, length=3, width=2\n"
+     ]
+    }
+   ],
+   "source": [
+    "bigm_model = build_strip_packing_model()\n",
+    "pyo.TransformationFactory(\"gdp.bigm\").apply_to(bigm_model)\n",
+    "result = solve_with_glpk(bigm_model)\n",
+    "\n",
+    "if result is not None:\n",
+    "    print(f\"minimum strip length: {pyo.value(bigm_model.total_length):.1f}\")\n",
+    "    for i in bigm_model.RECTANGLES:\n",
+    "        print(\n",
+    "            f\"rectangle {i}: x={pyo.value(bigm_model.x[i]):4.1f}, \"\n",
+    "            f\"y={pyo.value(bigm_model.y[i]):4.1f}, \"\n",
+    "            f\"length={pyo.value(bigm_model.Length[i]):.0f}, width={pyo.value(bigm_model.Width[i]):.0f}\"\n",
+    "        )\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b15a794b",
+   "metadata": {},
+   "source": [
+    "### Exercise 2.2. Inspect selected disjuncts\n",
+    "\n",
+    "The original disjunction objects remain attached to the transformed model, so you can still inspect which logical branch was selected after the solve.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "715a01ea",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-11T19:28:34.382278Z",
+     "iopub.status.busy": "2026-05-11T19:28:34.382157Z",
+     "iopub.status.idle": "2026-05-11T19:28:34.384847Z",
+     "shell.execute_reply": "2026-05-11T19:28:34.384347Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "pair (0, 1): j below i\n",
+      "pair (0, 2): i left of j\n",
+      "pair (0, 3): j below i\n",
+      "pair (1, 2): i below j\n",
+      "pair (1, 3): i left of j\n",
+      "pair (2, 3): j below i\n"
+     ]
+    }
+   ],
+   "source": [
+    "branch_labels = [\"i left of j\", \"j left of i\", \"i below j\", \"j below i\"]\n",
+    "\n",
+    "for pair in bigm_model.OVERLAP_PAIRS:\n",
+    "    choices = [bool(pyo.value(disjunct.indicator_var)) for disjunct in bigm_model.no_overlap[pair].disjuncts]\n",
+    "    selected = branch_labels[choices.index(True)] if any(choices) else \"no active branch\"\n",
+    "    print(f\"pair {pair}: {selected}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "31734c8d",
+   "metadata": {},
+   "source": [
+    "### Exercise 2.3. Compare big-M and hull transformations\n",
+    "\n",
+    "Solve the same GDP model with the hull reformulation. Compare the objective value and the number of generated variables and constraints.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "ed8bb76e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-11T19:28:34.386070Z",
+     "iopub.status.busy": "2026-05-11T19:28:34.385964Z",
+     "iopub.status.idle": "2026-05-11T19:28:34.461042Z",
+     "shell.execute_reply": "2026-05-11T19:28:34.460526Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "termination: optimal\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "termination: optimal\n",
+      "gdp.bigm: vars= 33, constraints= 34, objective=11.0\n",
+      "gdp.hull: vars=105, constraints=130, objective=11.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "comparison = []\n",
+    "for transformation in [\"gdp.bigm\", \"gdp.hull\"]:\n",
+    "    model = build_strip_packing_model()\n",
+    "    pyo.TransformationFactory(transformation).apply_to(model)\n",
+    "    result = solve_with_glpk(model)\n",
+    "    variables = len(list(model.component_data_objects(pyo.Var)))\n",
+    "    constraints = len(list(model.component_data_objects(pyo.Constraint, active=True)))\n",
+    "    objective = pyo.value(model.total_length) if result is not None else float(\"nan\")\n",
+    "    comparison.append((transformation, variables, constraints, objective))\n",
+    "\n",
+    "for transformation, variables, constraints, objective in comparison:\n",
+    "    print(f\"{transformation:8s}: vars={variables:3d}, constraints={constraints:3d}, objective={objective:.1f}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3c39736e",
+   "metadata": {},
+   "source": [
+    "## Exercises to continue\n",
+    "\n",
+    "1. Change one rectangle's width or length and resolve both transformations.\n",
+    "2. Add a fifth rectangle and observe how the number of rectangle-pair disjunctions grows.\n",
+    "3. Add rotation decisions, then decide whether the rotation alternatives should be modeled with additional binaries or GDP disjunctions.\n",
+    "\n",
+    "## References\n",
+    "\n",
+    "GDP models and transformations are part of Pyomo's modeling extensions [@bynum2021pyomo].\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/07-contrib-debugging/ContribAndDebugging.ipynb
+++ b/notebooks/07-contrib-debugging/ContribAndDebugging.ipynb
@@ -1,0 +1,378 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "32dcee44",
+   "metadata": {},
+   "source": [
+    "# Pyomo contrib and Debugging Tools\n",
+    "\n",
+    "[Open this notebook in Colab](https://colab.research.google.com/github/SECQUOIA/pyomo-summer-ws/blob/main/notebooks/07-contrib-debugging/ContribAndDebugging.ipynb).\n",
+    "\n",
+    "This notebook is part of the [SECQUOIA Research Group](https://engineering.purdue.edu/SECQUOIA) Pyomo Tutorial. It adapts the workshop's `pyomo.contrib` orientation and debugging guidance into small exercises that can be run without a commercial solver.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3361fea6",
+   "metadata": {},
+   "source": [
+    "## Learning objectives\n",
+    "\n",
+    "By the end of this chapter, you should be able to:\n",
+    "\n",
+    "- locate installed `pyomo.contrib` packages and recognize when a capability is an extension;\n",
+    "- use infeasibility logging to diagnose violated constraints at current variable values;\n",
+    "- detect suspicious scaling before handing a model to a nonlinear solver;\n",
+    "- check units consistency in a Pyomo model;\n",
+    "- add lightweight timing instrumentation while developing model-building code.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "b99bda05",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-11T19:28:34.049595Z",
+     "iopub.status.busy": "2026-05-11T19:28:34.049416Z",
+     "iopub.status.idle": "2026-05-11T19:28:34.219358Z",
+     "shell.execute_reply": "2026-05-11T19:28:34.218353Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import io\n",
+    "import logging\n",
+    "import pkgutil\n",
+    "import time\n",
+    "\n",
+    "import pyomo.environ as pyo\n",
+    "import pyomo.contrib\n",
+    "from pyomo.util.check_units import assert_units_consistent\n",
+    "from pyomo.util.infeasible import log_close_to_bounds, log_infeasible_constraints\n",
+    "from pyomo.util.report_scaling import report_scaling\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "40f2d356",
+   "metadata": {},
+   "source": [
+    "## 1. Finding extension capabilities\n",
+    "\n",
+    "The `pyomo.contrib` namespace contains tools that build on the core modeling objects: alternative solver interfaces, decomposition utilities, diagnostics, GDP-related algorithms, PyNumero interfaces, robust optimization tools, and more. Availability depends on the installed Pyomo version and optional third-party dependencies.\n",
+    "\n",
+    "### Exercise 1.1. List installed contrib packages\n",
+    "\n",
+    "Use Python package discovery to see what is installed in the current environment. Pick two names from the output and look them up in the Pyomo documentation before using them in production code.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "dd6ada06",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-11T19:28:34.221349Z",
+     "iopub.status.busy": "2026-05-11T19:28:34.221029Z",
+     "iopub.status.idle": "2026-05-11T19:28:34.226062Z",
+     "shell.execute_reply": "2026-05-11T19:28:34.225290Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "installed pyomo.contrib packages: 34\n",
+      "alternative_solutions, ampl_function_demo, appsi, aslfunctions, benders, community_detection, cp, cspline_external, doe, example, fbbt, fme, gdp_bounds, gdpopt, gjh, iis, incidence_analysis, interior_point\n"
+     ]
+    }
+   ],
+   "source": [
+    "contrib_names = sorted(name for _, name, _ in pkgutil.iter_modules(pyomo.contrib.__path__))\n",
+    "print(f\"installed pyomo.contrib packages: {len(contrib_names)}\")\n",
+    "print(\", \".join(contrib_names[:18]))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f05049c8",
+   "metadata": {},
+   "source": [
+    "## 2. Infeasibility checks\n",
+    "\n",
+    "Solver failures are easier to diagnose when you first evaluate the model at the values currently stored in the variables. The infeasibility utilities report constraints that are violated at those values.\n",
+    "\n",
+    "### Exercise 2.1. Log infeasible constraints\n",
+    "\n",
+    "The model below intentionally contains contradictory bounds on `x`. Capture the Pyomo log output and identify which constraints are violated.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "307188f4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-11T19:28:34.227639Z",
+     "iopub.status.busy": "2026-05-11T19:28:34.227449Z",
+     "iopub.status.idle": "2026-05-11T19:28:34.232415Z",
+     "shell.execute_reply": "2026-05-11T19:28:34.231390Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CONSTR lower_requirement: 1.0 </= 0\n",
+      "  - EXPR: 1.0 </= x\n",
+      "  - VAR x: 0\n",
+      "CONSTR upper_requirement: 0 </= -1.0\n",
+      "  - EXPR: x </= -1.0\n",
+      "  - VAR x: 0\n",
+      "x near LB of 0\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "infeasible = pyo.ConcreteModel()\n",
+    "infeasible.x = pyo.Var(initialize=0, bounds=(0, 2))\n",
+    "infeasible.lower_requirement = pyo.Constraint(expr=infeasible.x >= 1)\n",
+    "infeasible.upper_requirement = pyo.Constraint(expr=infeasible.x <= -1)\n",
+    "\n",
+    "stream = io.StringIO()\n",
+    "handler = logging.StreamHandler(stream)\n",
+    "logger = logging.getLogger(\"pyomo.util.infeasible\")\n",
+    "old_propagate = logger.propagate\n",
+    "logger.propagate = False\n",
+    "logger.setLevel(logging.INFO)\n",
+    "logger.addHandler(handler)\n",
+    "\n",
+    "log_infeasible_constraints(infeasible, log_expression=True, log_variables=True)\n",
+    "log_close_to_bounds(infeasible)\n",
+    "\n",
+    "logger.removeHandler(handler)\n",
+    "logger.propagate = old_propagate\n",
+    "print(stream.getvalue())\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "09185780",
+   "metadata": {},
+   "source": [
+    "## 3. Scaling checks\n",
+    "\n",
+    "Poor scaling can make nonlinear solves slow or unreliable. `report_scaling` uses bounds and expression analysis to flag variables, coefficients, and constraint bodies that may need rescaling.\n",
+    "\n",
+    "### Exercise 3.1. Report suspicious scaling\n",
+    "\n",
+    "The following model mixes variables near `1e-7` and `1e6`. Use the report to decide which variables or equations should be rescaled.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "1c8096be",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-11T19:28:34.233927Z",
+     "iopub.status.busy": "2026-05-11T19:28:34.233765Z",
+     "iopub.status.idle": "2026-05-11T19:28:34.238928Z",
+     "shell.execute_reply": "2026-05-11T19:28:34.238155Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "scaling check passed: False\n",
+      "\n",
+      "\n",
+      "The following variables have large bounds. Please scale them.\n",
+      "          LB          UB    Var\n",
+      "    0.00e+00    1.00e+08    y\n",
+      "\n",
+      "The following constraints have potentially large coefficients. Please scale them.\n",
+      "balance\n",
+      "         Coef LB     Coef UB    Var\n",
+      "        1.00e+08    1.00e+08    x\n",
+      "\n",
+      "The following constraints have bodies with large bounds. Please scale them.\n",
+      "          LB          UB    Constraint\n",
+      "    0.00e+00    1.00e+08    balance\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "scaled = pyo.ConcreteModel()\n",
+    "scaled.x = pyo.Var(initialize=1e-7, bounds=(0, 1e-6))\n",
+    "scaled.y = pyo.Var(initialize=1e6, bounds=(0, 1e8))\n",
+    "scaled.balance = pyo.Constraint(expr=1e8 * scaled.x + scaled.y == 1e6)\n",
+    "scaled.obj = pyo.Objective(expr=scaled.y)\n",
+    "\n",
+    "stream = io.StringIO()\n",
+    "handler = logging.StreamHandler(stream)\n",
+    "logger = logging.getLogger(\"pyomo.util.report_scaling\")\n",
+    "old_propagate = logger.propagate\n",
+    "logger.propagate = False\n",
+    "logger.setLevel(logging.INFO)\n",
+    "logger.addHandler(handler)\n",
+    "\n",
+    "scaling_ok = report_scaling(scaled, too_large=1e4, too_small=1e-5)\n",
+    "\n",
+    "logger.removeHandler(handler)\n",
+    "logger.propagate = old_propagate\n",
+    "print(f\"scaling check passed: {scaling_ok}\")\n",
+    "print(stream.getvalue())\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3104b3c8",
+   "metadata": {},
+   "source": [
+    "## 4. Unit checks\n",
+    "\n",
+    "Pyomo can attach units to variables, parameters, and expressions. Unit checks catch mistakes before the model is transformed or solved.\n",
+    "\n",
+    "### Exercise 4.1. Catch inconsistent units\n",
+    "\n",
+    "The constraint below tries to add a length and a time. Catch the exception and rewrite the expression with consistent units.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "b0ec52e7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-11T19:28:34.240280Z",
+     "iopub.status.busy": "2026-05-11T19:28:34.240110Z",
+     "iopub.status.idle": "2026-05-11T19:28:34.979010Z",
+     "shell.execute_reply": "2026-05-11T19:28:34.977791Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "InconsistentUnitsError\n",
+      "Error in units found in expression: length + time: meter not compatible with second.\n"
+     ]
+    }
+   ],
+   "source": [
+    "units_model = pyo.ConcreteModel()\n",
+    "units_model.length = pyo.Var(initialize=1, units=pyo.units.m)\n",
+    "units_model.time = pyo.Var(initialize=2, units=pyo.units.s)\n",
+    "units_model.bad_balance = pyo.Constraint(\n",
+    "    expr=units_model.length + units_model.time == 3 * pyo.units.m\n",
+    ")\n",
+    "\n",
+    "try:\n",
+    "    assert_units_consistent(units_model)\n",
+    "except Exception as err:\n",
+    "    print(type(err).__name__)\n",
+    "    print(str(err).splitlines()[0])\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2152f13b",
+   "metadata": {},
+   "source": [
+    "## 5. Timing model construction\n",
+    "\n",
+    "When a model is slow before the solver starts, instrument model construction in small pieces. The exact timing will vary by machine, but relative timing often identifies expensive loops or data transformations.\n",
+    "\n",
+    "### Exercise 5.1. Time a component-building loop\n",
+    "\n",
+    "Build a simple indexed constraint and report how many constraints were created per millisecond.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "bcc5f7a2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-11T19:28:34.981260Z",
+     "iopub.status.busy": "2026-05-11T19:28:34.980770Z",
+     "iopub.status.idle": "2026-05-11T19:28:34.987023Z",
+     "shell.execute_reply": "2026-05-11T19:28:34.986066Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "constraints built: 500\n",
+      "elapsed: 1.86 ms\n"
+     ]
+    }
+   ],
+   "source": [
+    "start = time.perf_counter()\n",
+    "timed = pyo.ConcreteModel()\n",
+    "timed.I = pyo.RangeSet(1, 500)\n",
+    "timed.x = pyo.Var(timed.I, bounds=(0, 10))\n",
+    "\n",
+    "@timed.Constraint(timed.I)\n",
+    "def upper_envelope(model, i):\n",
+    "    return model.x[i] <= 10 - i / 100\n",
+    "\n",
+    "timed.obj = pyo.Objective(expr=sum(timed.x[i] for i in timed.I), sense=pyo.maximize)\n",
+    "elapsed_ms = (time.perf_counter() - start) * 1000\n",
+    "print(f\"constraints built: {len(timed.upper_envelope)}\")\n",
+    "print(f\"elapsed: {elapsed_ms:.2f} ms\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ecd763d5",
+   "metadata": {},
+   "source": [
+    "## Exercises to continue\n",
+    "\n",
+    "1. Run the infeasibility utilities on one of the nonlinear exercise models after setting intentionally poor initial values.\n",
+    "2. Add units to the reactor-design exercise in [Pyomo Nonlinear Problems](../03-pyomo-nonlinear/PyomoNonlinear.ipynb), then call `assert_units_consistent`.\n",
+    "3. Time model construction before and after replacing a Python loop with an indexed Pyomo rule.\n",
+    "\n",
+    "## References\n",
+    "\n",
+    "The debugging utilities used here are distributed with Pyomo and complement the modeling guidance in the Pyomo references [@bynum2021pyomo].\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ docs = [
     "jupyterlab>=4.4,<5",
     "openpyxl>=3.1,<4",
     "pandas>=2.0,<3",
+    "pint>=0.24,<1",
     "pyomo>=6.9,<7",
 ]
 

--- a/setup.md
+++ b/setup.md
@@ -9,8 +9,13 @@ Use these links to open the published notebooks directly in Google Colab:
 - [Python Basics](https://colab.research.google.com/github/SECQUOIA/pyomo-summer-ws/blob/main/notebooks/01-python-basics/python-exercises.ipynb)
 - [Pyomo Fundamentals](https://colab.research.google.com/github/SECQUOIA/pyomo-summer-ws/blob/main/notebooks/02-pyomo-fundamentals/Fundamentals.ipynb)
 - [Pyomo Nonlinear Problems](https://colab.research.google.com/github/SECQUOIA/pyomo-summer-ws/blob/main/notebooks/03-pyomo-nonlinear/PyomoNonlinear.ipynb)
+- [Blocks and Model Transformations](https://colab.research.google.com/github/SECQUOIA/pyomo-summer-ws/blob/main/notebooks/04-structured-modeling/BlocksAndTransformations.ipynb)
+- [Dynamic Systems](https://colab.research.google.com/github/SECQUOIA/pyomo-summer-ws/blob/main/notebooks/05-dynamic-systems/DynamicSystems.ipynb)
+- [Generalized Disjunctive Programming](https://colab.research.google.com/github/SECQUOIA/pyomo-summer-ws/blob/main/notebooks/06-gdp/GDP.ipynb)
+- [Pyomo contrib and Debugging Tools](https://colab.research.google.com/github/SECQUOIA/pyomo-summer-ws/blob/main/notebooks/07-contrib-debugging/ContribAndDebugging.ipynb)
 
 The nonlinear notebook installs the IDAES extension bundle in Colab when IPOPT is missing. The fundamentals notebook uses GLPK for mixed-integer examples; install GLPK before running those cells in a fresh runtime.
+The dynamic-system notebook uses IPOPT for discretized optimization examples and SciPy for the simulation exercise; Colab includes SciPy by default.
 
 ## Local Environment
 

--- a/tests/test_book_content.py
+++ b/tests/test_book_content.py
@@ -172,6 +172,7 @@ class BookContentTests(unittest.TestCase):
 
         docs_dependencies = pyproject["dependency-groups"]["docs"]
         self.assertIn("jupyter-book==2.1.0", docs_dependencies)
+        self.assertIn("pint>=0.24,<1", docs_dependencies)
         self.assertEqual(["docs"], pyproject["tool"]["uv"]["default-groups"])
         self.assertFalse(pyproject["tool"]["uv"]["package"])
 

--- a/tests/test_book_content.py
+++ b/tests/test_book_content.py
@@ -11,6 +11,10 @@ PUBLISHED_NOTEBOOKS = (
     "notebooks/01-python-basics/python-exercises.ipynb",
     "notebooks/02-pyomo-fundamentals/Fundamentals.ipynb",
     "notebooks/03-pyomo-nonlinear/PyomoNonlinear.ipynb",
+    "notebooks/04-structured-modeling/BlocksAndTransformations.ipynb",
+    "notebooks/05-dynamic-systems/DynamicSystems.ipynb",
+    "notebooks/06-gdp/GDP.ipynb",
+    "notebooks/07-contrib-debugging/ContribAndDebugging.ipynb",
 )
 
 
@@ -270,15 +274,24 @@ class BookContentTests(unittest.TestCase):
         python_basics = notebook_source("notebooks/01-python-basics/python-exercises.ipynb")
         fundamentals = notebook_source("notebooks/02-pyomo-fundamentals/Fundamentals.ipynb")
         nonlinear = notebook_source("notebooks/03-pyomo-nonlinear/PyomoNonlinear.ipynb")
+        structured = notebook_source("notebooks/04-structured-modeling/BlocksAndTransformations.ipynb")
+        dynamic = notebook_source("notebooks/05-dynamic-systems/DynamicSystems.ipynb")
+        gdp = notebook_source("notebooks/06-gdp/GDP.ipynb")
+        debugging = notebook_source("notebooks/07-contrib-debugging/ContribAndDebugging.ipynb")
 
         self.assertIn("file: setup.md", myst)
         self.assertIn("## Learning objectives", intro)
         self.assertIn("## Learning objectives", python_basics)
         self.assertIn("## Learning objectives", fundamentals)
         self.assertIn("## Learning objectives", nonlinear)
+        self.assertIn("## Learning objectives", structured)
+        self.assertIn("## Learning objectives", dynamic)
+        self.assertIn("## Learning objectives", gdp)
+        self.assertIn("## Learning objectives", debugging)
         self.assertIn("Solutions Policy", setup)
         self.assertIn("GLPK", setup)
         self.assertIn("IPOPT", setup)
+        self.assertIn("SciPy", setup)
         self.assertIn("glpsol", setup)
         self.assertIn("ipopt", setup)
         self.assertIn("self-study build includes solution cells", python_basics)
@@ -309,6 +322,16 @@ class BookContentTests(unittest.TestCase):
             ),
             "notebooks/03-pyomo-nonlinear/PyomoNonlinear.ipynb": notebook_source(
                 "notebooks/03-pyomo-nonlinear/PyomoNonlinear.ipynb"
+            ),
+            "notebooks/04-structured-modeling/BlocksAndTransformations.ipynb": notebook_source(
+                "notebooks/04-structured-modeling/BlocksAndTransformations.ipynb"
+            ),
+            "notebooks/05-dynamic-systems/DynamicSystems.ipynb": notebook_source(
+                "notebooks/05-dynamic-systems/DynamicSystems.ipynb"
+            ),
+            "notebooks/06-gdp/GDP.ipynb": notebook_source("notebooks/06-gdp/GDP.ipynb"),
+            "notebooks/07-contrib-debugging/ContribAndDebugging.ipynb": notebook_source(
+                "notebooks/07-contrib-debugging/ContribAndDebugging.ipynb"
             ),
         }
 

--- a/tools/check_external_links.py
+++ b/tools/check_external_links.py
@@ -13,11 +13,16 @@ SOURCE_PATHS = (
     "README.md",
     "intro.md",
     "setup.md",
+    "THIRD_PARTY_NOTICES.md",
     "myst.yml",
     "requirements.txt",
     "notebooks/01-python-basics/python-exercises.ipynb",
     "notebooks/02-pyomo-fundamentals/Fundamentals.ipynb",
     "notebooks/03-pyomo-nonlinear/PyomoNonlinear.ipynb",
+    "notebooks/04-structured-modeling/BlocksAndTransformations.ipynb",
+    "notebooks/05-dynamic-systems/DynamicSystems.ipynb",
+    "notebooks/06-gdp/GDP.ipynb",
+    "notebooks/07-contrib-debugging/ContribAndDebugging.ipynb",
 )
 URL_RE = re.compile(r"https?://[^\s)>\"]+")
 

--- a/tools/check_static_site.py
+++ b/tools/check_static_site.py
@@ -12,9 +12,14 @@ BUILD_DIR = Path("_build/html")
 REQUIRED_ROUTES = (
     "index.html",
     "setup/index.html",
+    "third-party-notices/index.html",
     "notebooks/python-basics/python-exercises/index.html",
     "notebooks/pyomo-fundamentals/fundamentals/index.html",
     "notebooks/pyomo-nonlinear/pyomononlinear/index.html",
+    "notebooks/structured-modeling/blocksandtransformations/index.html",
+    "notebooks/dynamic-systems/dynamicsystems/index.html",
+    "notebooks/gdp/gdp/index.html",
+    "notebooks/contrib-debugging/contribanddebugging/index.html",
 )
 
 NOTEBOOK_COLAB_LINKS = {
@@ -29,6 +34,22 @@ NOTEBOOK_COLAB_LINKS = {
     "notebooks/pyomo-nonlinear/pyomononlinear/index.html": (
         "https://colab.research.google.com/github/SECQUOIA/pyomo-summer-ws/"
         "blob/main/notebooks/03-pyomo-nonlinear/PyomoNonlinear.ipynb"
+    ),
+    "notebooks/structured-modeling/blocksandtransformations/index.html": (
+        "https://colab.research.google.com/github/SECQUOIA/pyomo-summer-ws/"
+        "blob/main/notebooks/04-structured-modeling/BlocksAndTransformations.ipynb"
+    ),
+    "notebooks/dynamic-systems/dynamicsystems/index.html": (
+        "https://colab.research.google.com/github/SECQUOIA/pyomo-summer-ws/"
+        "blob/main/notebooks/05-dynamic-systems/DynamicSystems.ipynb"
+    ),
+    "notebooks/gdp/gdp/index.html": (
+        "https://colab.research.google.com/github/SECQUOIA/pyomo-summer-ws/"
+        "blob/main/notebooks/06-gdp/GDP.ipynb"
+    ),
+    "notebooks/contrib-debugging/contribanddebugging/index.html": (
+        "https://colab.research.google.com/github/SECQUOIA/pyomo-summer-ws/"
+        "blob/main/notebooks/07-contrib-debugging/ContribAndDebugging.ipynb"
     ),
 }
 EXPECTED_LOGO_TEXT = "Pyomo Tutorial"

--- a/uv.lock
+++ b/uv.lock
@@ -577,6 +577,30 @@ wheels = [
 ]
 
 [[package]]
+name = "flexcache"
+version = "0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/b0/8a21e330561c65653d010ef112bf38f60890051d244ede197ddaa08e50c1/flexcache-0.3.tar.gz", hash = "sha256:18743bd5a0621bfe2cf8d519e4c3bfdf57a269c15d1ced3fb4b64e0ff4600656", size = 15816, upload-time = "2024-03-09T03:21:07.555Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/cd/c883e1a7c447479d6e13985565080e3fea88ab5a107c21684c813dba1875/flexcache-0.3-py3-none-any.whl", hash = "sha256:d43c9fea82336af6e0115e308d9d33a185390b8346a017564611f1466dcd2e32", size = 13263, upload-time = "2024-03-09T03:21:05.635Z" },
+]
+
+[[package]]
+name = "flexparser"
+version = "0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/82/99/b4de7e39e8eaf8207ba1a8fa2241dd98b2ba72ae6e16960d8351736d8702/flexparser-0.4.tar.gz", hash = "sha256:266d98905595be2ccc5da964fe0a2c3526fbbffdc45b65b3146d75db992ef6b2", size = 31799, upload-time = "2024-11-07T02:00:56.249Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/5e/3be305568fe5f34448807976dc82fc151d76c3e0e03958f34770286278c1/flexparser-0.4-py3-none-any.whl", hash = "sha256:3738b456192dcb3e15620f324c447721023c0293f6af9955b481e91d00179846", size = 27625, upload-time = "2024-11-07T02:00:54.523Z" },
+]
+
+[[package]]
 name = "fqdn"
 version = "1.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1459,6 +1483,43 @@ wheels = [
 ]
 
 [[package]]
+name = "pint"
+version = "0.24.4"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+dependencies = [
+    { name = "flexcache", marker = "python_full_version < '3.11'" },
+    { name = "flexparser", marker = "python_full_version < '3.11'" },
+    { name = "platformdirs", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/20/bb/52b15ddf7b7706ed591134a895dbf6e41c8348171fb635e655e0a4bbb0ea/pint-0.24.4.tar.gz", hash = "sha256:35275439b574837a6cd3020a5a4a73645eb125ce4152a73a2f126bf164b91b80", size = 342225, upload-time = "2024-11-07T16:29:46.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/16/bd2f5904557265882108dc2e04f18abc05ab0c2b7082ae9430091daf1d5c/Pint-0.24.4-py3-none-any.whl", hash = "sha256:aa54926c8772159fcf65f82cc0d34de6768c151b32ad1deb0331291c38fe7659", size = 302029, upload-time = "2024-11-07T16:29:43.976Z" },
+]
+
+[[package]]
+name = "pint"
+version = "0.25.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
+]
+dependencies = [
+    { name = "flexcache", marker = "python_full_version >= '3.11'" },
+    { name = "flexparser", marker = "python_full_version >= '3.11'" },
+    { name = "platformdirs", marker = "python_full_version >= '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/9d/b1379cdbd33a49d17d627bc24e2b63cca06a1c5343b38072d2889499e82e/pint-0.25.3.tar.gz", hash = "sha256:f8f5df6cf65314d74da1ade1bf96f8e3e4d0c41b51577ac53c49e7d44ca5acee", size = 255106, upload-time = "2026-03-19T21:57:08.72Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/dd/a9fe6a0a09512da23951c68bf36466aeecd89def3183dc095edbc807ddc5/pint-0.25.3-py3-none-any.whl", hash = "sha256:27eb25143bd5de9fcc4d5a4b484f16faf6b4615aa93ece6b3373a8c1a3c1b97d", size = 307488, upload-time = "2026-03-19T21:57:07.022Z" },
+]
+
+[[package]]
 name = "platformdirs"
 version = "4.9.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1683,6 +1744,8 @@ docs = [
     { name = "jupyterlab" },
     { name = "openpyxl" },
     { name = "pandas" },
+    { name = "pint", version = "0.24.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "pint", version = "0.25.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pyomo" },
 ]
 
@@ -1696,6 +1759,7 @@ docs = [
     { name = "jupyterlab", specifier = ">=4.4,<5" },
     { name = "openpyxl", specifier = ">=3.1,<4" },
     { name = "pandas", specifier = ">=2.0,<3" },
+    { name = "pint", specifier = ">=0.24,<1" },
     { name = "pyomo", specifier = ">=6.9,<7" },
 ]
 


### PR DESCRIPTION
## Summary

- Add four executed tutorial chapters adapted from the current Pyomo tutorials material:
  - Blocks and Model Transformations
  - Dynamic Systems
  - Generalized Disjunctive Programming
  - Pyomo contrib and Debugging Tools
- Add the new chapters to the MyST/Jupyter Book table of contents and direct Colab-link validation.
- Update the landing page, setup guide, README, static-site checks, and external-link checks for the expanded tutorial sequence.
- Add third-party notice text for adapted Pyomo tutorial material.

## User impact

Learners now get a broader tutorial path that covers the missing advanced Pyomo topics already represented in the upstream tutorial repository and existing exercise files. The public site also validates the new routes and notebook-specific Colab links.

## Validation

- `python -m unittest discover -s tests` -> passed, 26 tests
- `~/.local/bin/uv run --group docs python -m unittest discover -s tests` -> passed, 26 tests
- `env BASE_URL=/pyomo-summer-ws ~/.local/bin/uv run --group docs jupyter book build --html --ci` -> passed, built 10 pages
- `~/.local/bin/uv run --group docs python tools/write_legacy_redirects.py` -> passed
- `~/.local/bin/uv run --group docs python tools/check_static_site.py` -> passed
- `~/.local/bin/uv run --group docs python tools/check_external_links.py` -> passed
- `git diff --check` -> passed

## Notes

- This is opened as a draft because it substantially expands published tutorial content and should get a content review before merge.
