### PR TITLE
Update dependencies for Dependabot alerts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      routine:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      security:
+        applies-to: "security-updates"
+        patterns:
+          - "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ docs = [
     "ccxt>=4,<5",
     "graphviz>=0.20,<1",
     "jupyter-book==2.1.0",
-    "jupyterlab>=4.4,<5",
+    "jupyterlab>=4.6.2,<5",
     "openpyxl>=3.1,<4",
     "pandas>=2.0,<3",
     "pint>=0.24,<1",
@@ -20,3 +20,8 @@ docs = [
 [tool.uv]
 package = false
 default-groups = ["docs"]
+constraint-dependencies = [
+    "mistune>=3.3.0",
+    "setuptools>=83.0.0",
+    "soupsieve>=2.8.4",
+]

--- a/tests/test_book_content.py
+++ b/tests/test_book_content.py
@@ -172,9 +172,28 @@ class BookContentTests(unittest.TestCase):
 
         docs_dependencies = pyproject["dependency-groups"]["docs"]
         self.assertIn("jupyter-book==2.1.0", docs_dependencies)
+        self.assertIn("jupyterlab>=4.6.2,<5", docs_dependencies)
         self.assertIn("pint>=0.24,<1", docs_dependencies)
         self.assertEqual(["docs"], pyproject["tool"]["uv"]["default-groups"])
+        self.assertEqual(
+            [
+                "mistune>=3.3.0",
+                "setuptools>=83.0.0",
+                "soupsieve>=2.8.4",
+            ],
+            pyproject["tool"]["uv"]["constraint-dependencies"],
+        )
         self.assertFalse(pyproject["tool"]["uv"]["package"])
+
+    def test_dependabot_keeps_uv_dependencies_current(self):
+        dependabot = (ROOT / ".github/dependabot.yml").read_text()
+
+        self.assertIn('package-ecosystem: "uv"', dependabot)
+        self.assertIn('interval: "weekly"', dependabot)
+        self.assertIn('applies-to: "version-updates"', dependabot)
+        self.assertIn('applies-to: "security-updates"', dependabot)
+        self.assertIn('"minor"', dependabot)
+        self.assertIn('"patch"', dependabot)
 
     def test_local_build_docs_match_ci_command(self):
         readme = (ROOT / "README.md").read_text()

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,13 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
+[manifest]
+constraints = [
+    { name = "mistune", specifier = ">=3.3.0" },
+    { name = "setuptools", specifier = ">=83.0.0" },
+    { name = "soupsieve", specifier = ">=2.8.4" },
+]
+
 [[package]]
 name = "aiodns"
 version = "4.0.0"
@@ -1773,7 +1780,7 @@ docs = [
     { name = "ccxt", specifier = ">=4,<5" },
     { name = "graphviz", specifier = ">=0.20,<1" },
     { name = "jupyter-book", specifier = "==2.1.0" },
-    { name = "jupyterlab", specifier = ">=4.4,<5" },
+    { name = "jupyterlab", specifier = ">=4.6.2,<5" },
     { name = "openpyxl", specifier = ">=3.1,<4" },
     { name = "pandas", specifier = ">=2.0,<3" },
     { name = "pint", specifier = ">=0.24,<1" },

--- a/uv.lock
+++ b/uv.lock
@@ -1041,7 +1041,7 @@ wheels = [
 
 [[package]]
 name = "jupyterlab"
-version = "4.6.1"
+version = "4.6.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "async-lru" },
@@ -1058,10 +1058,11 @@ dependencies = [
     { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "tornado" },
     { name = "traitlets" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bc/2a/d6af53bfd45a43a5bfe7e40ba47ee7a8921a807daf4bb708e3a295bbb54d/jupyterlab-4.6.1.tar.gz", hash = "sha256:75315982ed28427edaa62bb85eadb5105e4043a757643c910efd787fe6ed0837", size = 28179125, upload-time = "2026-06-29T12:48:45.402Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7a/7f/51c0c856ab286bdaf5709cf61ed13584ed9d4bee906479707da45b11b353/jupyterlab-4.6.2.tar.gz", hash = "sha256:e18ce8b34f3de350e93cd5b2c4f3ae884cbe266eb76bf5d6825a4ed34c13bcff", size = 28183650, upload-time = "2026-07-21T12:05:24.051Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/81/90ac6cc31d248e83a0d1eab343a5e6e68bc783d3f74fbe61640f42a61da4/jupyterlab-4.6.1-py3-none-any.whl", hash = "sha256:85a58546c831f3dce6cf919468c26874c9065e99c42279fb4abb8e1b552a98bb", size = 17164660, upload-time = "2026-06-29T12:48:41.21Z" },
+    { url = "https://files.pythonhosted.org/packages/63/1f/e39b248c76bb3736bc05a9491a6aa1315414c32dea12f548ecc1b24c758e/jupyterlab-4.6.2-py3-none-any.whl", hash = "sha256:5964447036629adfcd3fc0969effc1da6f47d2cbd0a60b2c2eea7c31be0ec6a8", size = 17166703, upload-time = "2026-07-21T12:05:19.818Z" },
 ]
 
 [[package]]
@@ -1155,14 +1156,14 @@ wheels = [
 
 [[package]]
 name = "mistune"
-version = "3.2.1"
+version = "3.3.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ca/84/620cc3f7e3adf6f5067e10f4dbae71295d8f9e16d5d3f9ef97c40f2f592c/mistune-3.2.1.tar.gz", hash = "sha256:7c8e5501d38bac1582e067e46c8343f17d57ea1aaa735823f3aba1fd59c88a28", size = 98003, upload-time = "2026-05-03T14:33:22.312Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/92/328a294a6de83bacb95bed01f04e0eaff4e3616ee359fc821a5dfc539b02/mistune-3.3.4.tar.gz", hash = "sha256:58b5c96d6fcb61190dfe5fae498d2b2065f99cf61e9649418fd54cf1ada86dfe", size = 121426, upload-time = "2026-07-22T05:22:30.89Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/7f/a946aa4f8752b37102b41e64dca18a1976ac705c3a0d1dfe74d820a02552/mistune-3.2.1-py3-none-any.whl", hash = "sha256:78cdb0ba5e938053ccf63651b352508d2efa9411dc8810bfb05f2dc5140c0048", size = 53749, upload-time = "2026-05-03T14:33:20.551Z" },
+    { url = "https://files.pythonhosted.org/packages/77/e4/288365afae98953bc01de09f686f40d8ee84578135aa7767d5d4e60b5278/mistune-3.3.4-py3-none-any.whl", hash = "sha256:ee015381e955e370962968befe1d729ab60fafb6a715ac6751763fbce38c8d4a", size = 66862, upload-time = "2026-07-22T05:22:29.419Z" },
 ]
 
 [[package]]
@@ -2047,11 +2048,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "82.0.1"
+version = "83.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
 ]
 
 [[package]]
@@ -2065,11 +2066,11 @@ wheels = [
 
 [[package]]
 name = "soupsieve"
-version = "2.8.3"
+version = "2.9.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/38/e12680bbe6b4f8f3d17adcaf38d26850aa756c85cf4a80e79fc12a018fe8/soupsieve-2.9.1.tar.gz", hash = "sha256:c33e6605bbc71dd628b00c632d58ae607c22bade247e52553928f83bbb75b4ba", size = 122261, upload-time = "2026-07-21T16:57:17.452Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/2c/437fe806897c2d6cfdc3ee43a18da8bf8e568530a4ae9bac781541ca9896/soupsieve-2.9.1-py3-none-any.whl", hash = "sha256:4f4477399246b7a0c720a88ca2454b11cd6bb9ae4c9d170140786e916776c14c", size = 37404, upload-time = "2026-07-21T16:57:16.421Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- update JupyterLab from 4.6.1 to 4.6.2
- update Mistune from 3.2.1 to 3.3.4
- update Setuptools from 82.0.1 to 83.0.0
- update SoupSieve from 2.8.3 to 2.9.1
- resolve all 18 currently open Dependabot alerts once merged (8 high, 9 moderate, 1 low)
- encode minimum safe versions in `pyproject.toml` so vulnerable releases cannot be selected again
- add weekly grouped `uv` version and security update configuration
- add regression coverage for the dependency security policy

## Verification

- `uv lock --check`
- `uv sync --locked --group docs`
- `uv run --locked --group docs python -m unittest discover -s tests` (27 passed)
- `uv audit --locked` (no known vulnerabilities or adverse project statuses in 126 packages)
- `BASE_URL=/pyomo-summer-ws uv run --locked --group docs jupyter book build --html --ci`
- `uv run --locked --group docs python tools/write_legacy_redirects.py`
- `uv run --locked --group docs python tools/check_static_site.py`
- Dependabot YAML parse and policy validation
- generated URL double-slash check
- `git diff --check`

## Follow-up

Enable Dependabot security updates in repository settings after this PR merges, so GitHub does not create duplicate security PRs for the alerts already fixed here.